### PR TITLE
Switch routing to POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # hono-cli-adapter
 
-Tiny library to adapt CLI arguments into a GET request for a Hono app — without touching stdout. It lets you build a small custom CLI around an existing Hono application, while keeping this package a pure, testable library.
+Tiny library to adapt CLI arguments into a POST request for a Hono app — without touching stdout. It lets you build a small custom CLI around an existing Hono application, while keeping this package a pure, testable library.
 
 Status: minimal but usable. ESM-only.
 
 ## Why
 - Keep your CLI thin: printing, JSON formatting, and flags live in your own small bin.
 - Library has no side effects: never writes to stdout/stderr.
-- Strong constraints: GET-only philosophy for predictable, cacheable calls from the shell.
+- Strong constraints: POST-only philosophy for predictable calls from the shell.
 - Reserved flags: easily exclude your CLI-only flags from HTTP query strings.
 - Env merging: combine `options.env` with repeated `--env KEY=VALUE` flags.
 
@@ -54,7 +54,7 @@ type AdapterOptions = {
   reservedKeys?: string[]
 }
 
-function listGetRoutes(app: any): string[]
+function listPostRoutes(app: any): string[]
 function buildUrlFromArgv(argv: minimist.ParsedArgs, options?: AdapterOptions): URL
 function parseEnvFlags(envFlags: string | string[] | undefined): Record<string, string>
 function buildRequestFromArgv(argv: minimist.ParsedArgs, options?: AdapterOptions): Request
@@ -79,8 +79,8 @@ function runCliAndExit(app: any, argvRaw?: string[], options?: AdapterOptions): 
 Key behaviors:
 - Reserved keys default to `['_', '--', 'base', 'env']` and are removed from the query string. Add your own via `options.reservedKeys`.
 - `--env KEY=VALUE` can be repeated; merged into `options.env` with flags taking precedence on conflicts.
-- `buildRequestFromArgv` and `adaptAndFetch` use GET only.
-- `listGetRoutes` is best-effort and relies on Hono’s internal shape. It enumerates GET paths only.
+- `buildRequestFromArgv` and `adaptAndFetch` use POST only.
+- `listPostRoutes` is best-effort and relies on Hono’s internal shape. It enumerates POST paths only.
 
 ## Usage Patterns
 Two ways to integrate:
@@ -101,8 +101,8 @@ const res = await app.fetch(req, { ...parseEnvFlags(argv.env) })
 
 // Show routes plus runnable examples (you print; library does not):
 const { routes, examples } = listRoutesWithExamples(app, detectCommandBase())
-console.log('GET routes:')
-for (const p of routes) console.log('  GET ' + p)
+console.log('POST routes:')
+for (const p of routes) console.log('  POST ' + p)
 console.log('\nCommand examples:')
 for (const ex of examples) console.log('  ' + ex)
 ```
@@ -130,7 +130,7 @@ npm run build:example:bin
 ```
 
 ## Design Notes
-- GET-only now; adding POST/others can be an additive future feature when/if needed.
+- POST-only now; adding other methods can be an additive future feature when/if needed.
 - The adapter never writes to stdout — your CLI formats results (plain text, JSON, etc.).
 - Use `reservedKeys` to prevent your CLI flags (e.g. `--json`, `--list`) from leaking into HTTP queries.
 
@@ -139,7 +139,7 @@ npm run build:example:bin
 - Node 18+ recommended. If you don’t have global `fetch`, polyfill (e.g. `undici`).
 
 ## Caveats
-- `listGetRoutes` depends on Hono internals and may break if they change. Consider maintaining your own list if you need strong guarantees.
+- `listPostRoutes` depends on Hono internals and may break if they change. Consider maintaining your own list if you need strong guarantees.
 
 ## Development
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -43,7 +43,7 @@ This produces `example/bin/hono-example`.
 
 Flags understood by the CLI:
 
-- `--list` — print runnable command examples (derived from GET routes)
+- `--list` — print runnable command examples (derived from POST routes)
 - `--help`, `-h` — same output as `--list`
 - `--json` — JSON-format the response (best-effort). For text endpoints, it wraps text as `{ status, data }`.
 - `--base` — prefix base path (e.g. `/v1`)

--- a/example/app.mjs
+++ b/example/app.mjs
@@ -2,29 +2,29 @@ import { Hono } from 'hono'
 
 const app = new Hono()
 
-app.get('/', (c) => c.text('Hello from Hono'))
+app.post('/', (c) => c.text('Hello from Hono'))
 
-app.get('/help', (c) => {
+app.post('/help', (c) => {
   const name = 'hono-example'
-  const routes = (app?.routes ?? []).filter((r) => r?.method === 'GET')
+  const routes = (app?.routes ?? []).filter((r) => r?.method === 'POST')
   const lines = [
     'hono-cli-adapter example',
     '',
     `Usage: ${name} [segments...] [--json] [--list] [--base /v1] [--env KEY=VALUE]`,
     '',
-    'GET routes:'
+    'POST routes:'
   ]
-  for (const r of routes) lines.push(`  GET ${r.path}`)
+  for (const r of routes) lines.push(`  POST ${r.path}`)
   lines.push('')
   return c.text(lines.join('\n'))
 })
 
-app.get('/hello/:name', (c) => {
+app.post('/hello/:name', (c) => {
   const name = c.req.param('name')
   return c.text(`Hello, ${name}!`)
 })
 
-app.get('/env/:key', (c) => {
+app.post('/env/:key', (c) => {
   const key = c.req.param('key')
   const val = (c.env ?? {})[key]
   return c.text(`${key}=${val ?? ''}`)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "license": "MIT",
-  "description": "Adapt CLI argv to a GET Request for a Hono app (ESM).",
+  "description": "Adapt CLI argv to a POST Request for a Hono app (ESM).",
   "author": "K.Endo",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,12 +15,12 @@ export type AdapterOptions = {
 const DEFAULT_RESERVED = new Set(['_', '--', 'base', 'env'])
 
 /**
- * Roughly list GET routes from a Hono app.
+ * Roughly list POST routes from a Hono app.
  * Note: this relies on Hono's internal shape (best-effort snapshot).
  */
-export function listGetRoutes(app: any): string[] {
+export function listPostRoutes(app: any): string[] {
   const routes = (app as any)?.routes ?? []
-  return routes.filter((r: any) => r?.method === 'GET').map((r: any) => r.path)
+  return routes.filter((r: any) => r?.method === 'POST').map((r: any) => r.path)
 }
 
 /**
@@ -76,14 +76,14 @@ export function parseEnvFlags(
 }
 
 /**
- * Create a Request from argv (method fixed to GET).
+ * Create a Request from argv (method fixed to POST).
  */
 export function buildRequestFromArgv(
   argv: minimist.ParsedArgs,
   options?: AdapterOptions
 ): Request {
   const url = buildUrlFromArgv(argv, options)
-  return new Request(url, { method: 'GET' })
+  return new Request(url, { method: 'POST' })
 }
 
 /**
@@ -151,18 +151,18 @@ export function detectCommandBase(
   return runtime || execBase || 'hono-example'
 }
 
-/** Convenience: list GET routes and produce command examples. */
+/** Convenience: list POST routes and produce command examples. */
 export function listRoutesWithExamples(app: any, cmdBase?: string): { routes: string[]; examples: string[] } {
-  const routes = listGetRoutes(app)
+  const routes = listPostRoutes(app)
   const base = cmdBase ?? detectCommandBase()
   const examples = buildCommandExamples(routes, base)
   return { routes, examples }
 }
 
-/** Convenience: produce only command examples for GET routes. */
+/** Convenience: produce only command examples for POST routes. */
 export function listCommandExamples(app: any, cmdBase?: string): string[] {
   const base = cmdBase ?? detectCommandBase()
-  return buildCommandExamples(listGetRoutes(app), base)
+  return buildCommandExamples(listPostRoutes(app), base)
 }
 
 export type RunCliResult = {


### PR DESCRIPTION
## Summary
- use POST for requests built from CLI arguments
- enumerate POST routes for command examples
- update docs and example to reflect POST-only design

## Testing
- `npm run build`
- `node example/cli.mjs --list`


------
https://chatgpt.com/codex/tasks/task_b_68b285e2672c83259d299755b10a9200