### PR TITLE
feat: add beforeFetch hook and command helper

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,44 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import minimist from 'minimist'
+import { Hono } from 'hono'
+import {
+  commandFromArgv,
+  adaptAndFetch
+} from '../dist/index.js'
+
+// commandFromArgv tests
+
+test('commandFromArgv extracts first segment', () => {
+  const argv1 = minimist(['foo'])
+  assert.equal(commandFromArgv(argv1), 'foo')
+  const argv2 = minimist(['foo', 'bar'])
+  assert.equal(commandFromArgv(argv2), 'foo')
+  const argv3 = minimist([])
+  assert.equal(commandFromArgv(argv3), undefined)
+})
+
+// beforeFetch map test
+
+test('beforeFetch map applies only matching hook', async () => {
+  const app = new Hono()
+  app.post('/upload', async (c) => c.text(c.req.header('x-test') || ''))
+  let called = false
+  let otherCalled = false
+  const { res } = await adaptAndFetch(app, ['upload'], {
+    beforeFetch: {
+      upload: (req) => {
+        called = true
+        const headers = new Headers(req.headers)
+        headers.set('x-test', 'ok')
+        return new Request(req, { headers })
+      },
+      other: () => {
+        otherCalled = true
+      }
+    }
+  })
+  assert.equal(await res.text(), 'ok')
+  assert.equal(called, true)
+  assert.equal(otherCalled, false)
+})


### PR DESCRIPTION
## Summary
- add `commandFromArgv` helper
- support `beforeFetch` hook for request customization and per-command hooks
- document hook usage and safe command detection
- remove unused `transformBody` option

## Testing
- `npm run build`
- `node --test test/index.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b2a07c5c808325b4204eab92fa0d39