### PR TITLE
feat: include OpenAPI parameters in CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ function buildCommandExamples(routes: string[], cmdBase: string): string[]
 function detectCommandBase(argv0?: string, argv1?: string): string
 function listRoutesWithExamples(app: any, cmdBase?: string): { routes: string[]; examples: string[] }
 function listCommandExamples(app: any, cmdBase?: string): string[]
+type OpenApiParam = { name: string; in: string; required?: boolean; description?: string; schema?: any }
+function listRoutesWithExamplesFromOpenApi(openapi: any, cmdBase?: string): { routes: string[]; examples: string[]; params: OpenApiParam[][] }
 type RunCliResult = { code: number; lines: string[]; req?: Request; res?: Response }
 function runCliDefault(app: any, argvRaw?: string[], options?: AdapterOptions): Promise<RunCliResult>
 // Convenience with side effects (stdout + process.exit when available)
@@ -112,6 +114,49 @@ console.log('POST routes:')
 for (const p of routes) console.log('  POST ' + p)
 console.log('\nCommand examples:')
 for (const ex of examples) console.log('  ' + ex)
+```
+
+From an OpenAPI 3 spec you can also list routes, runnable examples, and parameter details:
+
+```ts
+import { listRoutesWithExamplesFromOpenApi } from 'hono-cli-adapter'
+
+const openapi = {
+  paths: {
+    '/user/{id}': {
+      post: {
+        parameters: [
+          { name: 'email', in: 'query', required: true, description: 'user email', schema: { type: 'string' } }
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { age: { type: 'integer', description: 'user age' } },
+                required: ['age']
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+const { examples, params } = listRoutesWithExamplesFromOpenApi(openapi, 'cmd')
+console.log(examples[0])
+for (const p of params[0].filter((p) => p.in !== 'path')) {
+  console.log(`  --${p.name} (${p.schema?.type}${p.required ? ', required' : ''}) : ${p.description}`)
+}
+```
+
+Outputs:
+
+```
+cmd user <id> --email <email> --age <age>
+  --email (string, required) : user email
+  --age (integer, required) : user age
 ```
 
 ### Hooks and command detection

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,75 @@ export function listCommandExamples(app: any, cmdBase?: string): string[] {
   return buildCommandExamples(listPostRoutes(app), base)
 }
 
+export type OpenApiParam = {
+  name: string
+  in: string
+  required?: boolean
+  description?: string
+  schema?: any
+}
+
+export function listRoutesWithExamplesFromOpenApi(
+  openapi: any,
+  cmdBase?: string
+): { routes: string[]; examples: string[]; params: OpenApiParam[][] } {
+  const paths = openapi?.paths || {}
+  const base = cmdBase ?? detectCommandBase()
+  const routes: string[] = []
+  const examples: string[] = []
+  const params: OpenApiParam[][] = []
+
+  for (const [rawPath, item] of Object.entries<any>(paths)) {
+    const post = (item as any)?.post
+    if (!post) continue
+
+    const route = String(rawPath).replace(/\{(.*?)\}/g, ':$1')
+    routes.push(route)
+
+    const paramList: OpenApiParam[] = []
+    const collect = (arr: any[] | undefined) => {
+      for (const p of arr || []) {
+        paramList.push({
+          name: p.name,
+          in: p.in,
+          required: p.required,
+          description: p.description,
+          schema: p.schema
+        })
+      }
+    }
+    collect((item as any).parameters)
+    collect(post.parameters)
+
+    const schema = (post as any)?.requestBody?.content?.['application/json']?.schema
+    if (schema?.type === 'object' && schema.properties) {
+      const required: string[] = schema.required || []
+      for (const [name, prop] of Object.entries<any>(schema.properties)) {
+        paramList.push({
+          name,
+          in: 'body',
+          required: required.includes(name),
+          description: (prop as any)?.description,
+          schema: prop
+        })
+      }
+    }
+
+    params.push(paramList)
+
+    const segs = routePathToCommandSegments(route)
+    let example = base + (segs.length ? ' ' + segs.join(' ') : '')
+    for (const p of paramList) {
+      if (p.in === 'query' || p.in === 'body') {
+        example += ` --${p.name} <${p.name}>`
+      }
+    }
+    examples.push(example)
+  }
+
+  return { routes, examples, params }
+}
+
 export type RunCliResult = {
   code: number
   lines: string[]


### PR DESCRIPTION
## Summary
- support extracting path, query, and body parameters from OpenAPI specs
- extend listRoutesWithExamplesFromOpenApi to return parameter metadata
- document parameter-aware help examples

## Testing
- `npm run build`
- `node --test test/index.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b3c93ce8588325ab6274924efc6b2b