### PR TITLE
feat: show global flags in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Quick taste:
 ```
 npm run build
 node example/basic/cli.mjs --list   # prints runnable command examples only
-node example/basic/cli.mjs --help   # same as --list
+node example/basic/cli.mjs --help   # adds a Flags section
 node example/basic/cli.mjs hello Taro         # -> "Hello, Taro!"
 node example/basic/cli.mjs env API_KEY --env API_KEY=secret-123   # -> "API_KEY=secret-123"
 ```
@@ -207,7 +207,7 @@ Single-file binary via Bun:
 ```
 npm run build:example:bin
 ./example/basic/bin/hono-example --list
-./example/basic/bin/hono-example --help
+./example/basic/bin/hono-example --help   # shows flags
 ```
 
 ## Design Notes

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,8 @@ import { Hono } from 'hono'
 import {
   commandFromArgv,
   adaptAndFetch,
-  listRoutesWithExamplesFromOpenApi
+  listRoutesWithExamplesFromOpenApi,
+  runCliDefault
 } from '../dist/index.js'
 
 // commandFromArgv tests
@@ -92,4 +93,12 @@ test('listRoutesWithExamplesFromOpenApi extracts params', () => {
     '--email (string, required) : user email',
     '--age (integer, required) : user age'
   ])
+})
+
+test('runCliDefault help lists global flags', async () => {
+  const app = new Hono()
+  app.post('/ping', (c) => c.text('pong'))
+  const { lines } = await runCliDefault(app, ['--help'])
+  assert.equal(lines.includes('Flags:'), true)
+  assert(lines.some((l) => l.includes('--json')))
 })


### PR DESCRIPTION
## Summary
- expose `globalFlagTypes` from minimist config
- append flag descriptions in `--help` output
- document flag section in README

## Testing
- `npm run build`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_b_68b45203772883258ee467696ee3a5d3